### PR TITLE
feat: add nixos-anywhere and agenix to dev shell

### DIFF
--- a/parts/devshell.nix
+++ b/parts/devshell.nix
@@ -1,7 +1,7 @@
 # Dev shell — provides all tools needed for voxnix development.
 #
 # Enter with: nix develop
-{ ... }:
+{ inputs, ... }:
 {
   perSystem =
     { config, pkgs, ... }:
@@ -21,6 +21,10 @@
           just
           jq
           config.treefmt.build.wrapper
+
+          # Deployment
+          pkgs.nixos-anywhere # initial provisioning: just provision <ip>
+          inputs.agenix.packages.${pkgs.system}.default # secret management: agenix -e, agenix --rekey
         ];
 
         shellHook = ''


### PR DESCRIPTION
Both tools are required for the deployment workflow but were missing from the dev shell.

- `nixos-anywhere` — from nixpkgs, used by `just provision <ip>`
- `agenix` — from the agenix flake input (not in nixpkgs), used for `agenix -e` and `agenix --rekey`

After `nix develop`, both commands are available without any separate installation.