### PR TITLE
chore: provision setup — admin SSH key, age key, encrypted secrets

### DIFF
--- a/nix/host/default.nix
+++ b/nix/host/default.nix
@@ -58,9 +58,7 @@
       "systemd-journal"
     ];
     openssh.authorizedKeys.keys = [
-      # TODO: Replace with your SSH public key before first deploy.
-      # Generate with: ssh-keygen -t ed25519 -C "admin@voxnix"
-      "ssh-ed25519 AAAA_REPLACE_WITH_YOUR_PUBLIC_KEY admin@voxnix"
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMYEMoAMxPAGD4AzBPCAYV6UiHrAeMm/AJIGXKCikkuc"
     ];
     # No password — SSH key only.
     hashedPassword = "!";

--- a/secrets/agent-env.age
+++ b/secrets/agent-env.age
@@ -1,1 +1,6 @@
-# Placeholder â€” replace with agenix-encrypted env file. See secrets/README.md.
+age-encryption.org/v1
+-> X25519 zuKkqRPvGTThbzgpC4rs+i22JeAZ5UgkJjYYRVTX7TU
+y0LSPCIhjmU05RzyqDKJTdAlQqyTcWBjCDqZP17xRHU
+--- wSeJJeWMxt5tbs63XSGK61Fl7p/bascmsM31ea0uZxs
+îåB+‰övž’ŠGò÷Ë91†pkèíóƒRñÐ‘DCˆî169Bþ°“Ä7t 'ú$ÄGM^‘÷®Ê*ÓÓŽ«|Ïð n9Ë4[Vj¾*Àž¥óØT¹CC_Ç6‹ÎµçÑjšÜÝJ8'zwæ½k|‹÷vOïû·’º}¨mØÔ+“•v7'†ãÓŒøŸl±ŽüXüš<pCþ29ÌR%Š»YQººµâÀ<÷…¶ä9Œ®"ÛœvuäxAô.Ô˜³
+³®¦~aïÙ£~¡|±â{^Ã]×‹È›F@4õ¾²L’>Ü¶úÝÞ

--- a/secrets/secrets.nix
+++ b/secrets/secrets.nix
@@ -23,7 +23,7 @@ let
   # Your personal age public key (on your MacBook / deployment machine).
   # This lets you encrypt and edit secrets from your laptop.
   # Generate with: age-keygen -o ~/.config/age/voxnix.txt
-  admin = "age1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+  admin = "age13k6t6ww23ryatnnda755lk0ksrpc6vv3sd79ry7mh9q8vmgcl40q85ya5u";
 
   # The NixOS appliance's SSH public key (the Hyper-V VM, not your MacBook).
   # This lets the appliance decrypt its own secrets at boot.


### PR DESCRIPTION
Pre-provision setup: admin SSH public key added, age key generated, agent-env.age encrypted with real credentials. Ready to provision.