### PR TITLE
fix: provision confirmation prompt compatibility

### DIFF
--- a/justfile
+++ b/justfile
@@ -49,7 +49,7 @@ provision target:
     @echo "⚠️  This will FORMAT THE DISK on {{ target }}. All existing data will be destroyed."
     @echo "   Target: root@{{ target }}"
     @echo ""
-    @bash -c 'read -p "Type the target IP to confirm: " confirm && [ "$$confirm" = "{{ target }}" ] || (echo "Aborted."; exit 1)'
+    @printf "Type the target IP to confirm: " && read confirm && [ "$$confirm" = "{{ target }}" ] || (echo "Aborted."; exit 1)
     @echo ""
     @echo "Checking SSH connectivity to root@{{ target }}..."
     @ssh -q -o ConnectTimeout=5 -o BatchMode=yes -o StrictHostKeyChecking=no root@{{ target }} exit 2>/dev/null || \


### PR DESCRIPTION
The `read -p` form inside `bash -c` wasn't working reliably — the prompt appeared but input wasn't captured correctly, causing the confirmation to always abort. Replaced with `printf` + `read` which works portably across sh/bash.