### PR TITLE
fix: rewrite provision recipe as bash script

### DIFF
--- a/justfile
+++ b/justfile
@@ -46,13 +46,21 @@ deploy target:
 
 # Provision a new appliance (one-time, destructive — formats the target disk)
 provision target:
-    @echo "⚠️  This will FORMAT THE DISK on {{ target }}. All existing data will be destroyed."
-    @echo "   Target: root@{{ target }}"
-    @echo ""
-    @printf "Type the target IP to confirm: " && read confirm && [ "$$confirm" = "{{ target }}" ] || (echo "Aborted."; exit 1)
-    @echo ""
-    @echo "Checking SSH connectivity to root@{{ target }}..."
-    @ssh -q -o ConnectTimeout=5 -o BatchMode=yes -o StrictHostKeyChecking=no root@{{ target }} exit 2>/dev/null || \
-        (echo "❌ Cannot reach root@{{ target }} — is the NixOS installer running? Did you set a root password?"; exit 1)
-    @echo "✅ SSH OK — starting provisioning..."
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "⚠️  This will FORMAT THE DISK on {{ target }}. All existing data will be destroyed."
+    echo "   Target: root@{{ target }}"
+    echo ""
+    read -p "Type the target IP to confirm: " confirm
+    if [ "$confirm" != "{{ target }}" ]; then
+        echo "Aborted."
+        exit 1
+    fi
+    echo ""
+    echo "Checking SSH connectivity to root@{{ target }}..."
+    if ! ssh -q -o ConnectTimeout=5 -o BatchMode=yes -o StrictHostKeyChecking=no root@{{ target }} exit 2>/dev/null; then
+        echo "❌ Cannot reach root@{{ target }} — is the NixOS installer running? Did you set a root password?"
+        exit 1
+    fi
+    echo "✅ SSH OK — starting provisioning..."
     nixos-anywhere --flake .#appliance root@{{ target }}


### PR DESCRIPTION
The previous approach ran each line in a separate subshell, so the `read` result was lost before the comparison. Using a shebang (`#!/usr/bin/env bash`) makes the whole recipe a single bash script where variables persist across lines.