### PR TITLE
fix: use nix run nixpkgs#nixos-rebuild for macOS compatibility

### DIFF
--- a/justfile
+++ b/justfile
@@ -42,7 +42,7 @@ deploy target:
     @ssh -q -o ConnectTimeout=5 -o BatchMode=yes admin@{{ target }} exit 2>/dev/null || \
         (echo "❌ Cannot reach admin@{{ target }} — is the appliance running?"; exit 1)
     @echo "✅ SSH OK — starting rebuild..."
-    nixos-rebuild switch --flake .#appliance --target-host admin@{{ target }} --use-remote-sudo
+    nix run nixpkgs#nixos-rebuild -- switch --flake .#appliance --target-host admin@{{ target }} --use-remote-sudo
 
 # Edit the encrypted secrets file
 secrets-edit:


### PR DESCRIPTION
`nixos-rebuild` is not available on macOS. `nix run nixpkgs#nixos-rebuild` downloads and runs it on demand, working from any platform.