### PR TITLE
fix: build NixOS closure on appliance for cross-arch deploy

### DIFF
--- a/justfile
+++ b/justfile
@@ -42,7 +42,7 @@ deploy target:
     @ssh -q -o ConnectTimeout=5 -o BatchMode=yes admin@{{ target }} exit 2>/dev/null || \
         (echo "❌ Cannot reach admin@{{ target }} — is the appliance running?"; exit 1)
     @echo "✅ SSH OK — starting rebuild..."
-    nix run nixpkgs#nixos-rebuild -- switch --flake .#appliance --target-host admin@{{ target }} --use-remote-sudo
+    nix run nixpkgs#nixos-rebuild -- switch --flake .#appliance --target-host admin@{{ target }} --build-host admin@{{ target }} --sudo
 
 # Edit the encrypted secrets file
 secrets-edit:


### PR DESCRIPTION
MacBook is Apple Silicon (aarch64-darwin). nixos-rebuild was trying to build the x86_64-linux NixOS closure locally, which fails. `--build-host admin@\<target\>` sends the build to the appliance itself. Also replaces deprecated `--use-remote-sudo` with `--sudo`.